### PR TITLE
feat(admin): Mejoras en el módulo de usuarios y flujo de contraseñas

### DIFF
--- a/api/src/controllers/user.controller.ts
+++ b/api/src/controllers/user.controller.ts
@@ -9,7 +9,6 @@ import { comparePassword } from '../utils/password';
 
 export const createUserValidation = [
   body('email').isEmail().withMessage('Email válido requerido'),
-  body('password').isLength({ min: 8 }).withMessage('La contraseña debe tener al menos 8 caracteres'),
   body('firstName').notEmpty().withMessage('Nombre requerido'),
   body('lastName').notEmpty().withMessage('Apellido requerido'),
   body('dateOfBirth').optional().isISO8601().withMessage('Fecha de nacimiento válida requerida'),
@@ -258,6 +257,40 @@ export class UserController {
       res.status(200).json({
         success: true,
         message: result.message,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async resendConfirmation(req: AuthRequest, res: Response, next: NextFunction): Promise<void> {
+    try {
+      if (req.user?.role !== ROLES.ADMIN) {
+        res.status(403).json({ success: false, message: 'Insufficient permissions' });
+        return;
+      }
+      const { id } = req.params;
+      await userService.resendConfirmation(id);
+      res.status(200).json({
+        success: true,
+        message: 'Correo de confirmación reenviado con éxito.',
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async resetPasswordByAdmin(req: AuthRequest, res: Response, next: NextFunction): Promise<void> {
+    try {
+      if (req.user?.role !== ROLES.ADMIN) {
+        res.status(403).json({ success: false, message: 'Insufficient permissions' });
+        return;
+      }
+      const { id } = req.params;
+      await userService.resetPasswordByAdmin(id);
+      res.status(200).json({
+        success: true,
+        message: 'Contraseña restablecida con éxito. Se ha enviado un correo con las nuevas credenciales.',
       });
     } catch (error) {
       next(error);

--- a/api/src/routes/user.routes.ts
+++ b/api/src/routes/user.routes.ts
@@ -34,4 +34,19 @@ router.post(
   userController.create.bind(userController)
 );
 
+// Acciones adicionales de admin
+router.post(
+  '/:id/resend-confirmation',
+  authorizeRoles(ROLES.ADMIN),
+  validate([param('id').isUUID()]),
+  userController.resendConfirmation.bind(userController)
+);
+
+router.post(
+  '/:id/reset-password-admin',
+  authorizeRoles(ROLES.ADMIN),
+  validate([param('id').isUUID()]),
+  userController.resetPasswordByAdmin.bind(userController)
+);
+
 export default router;

--- a/api/src/services/email.service.ts
+++ b/api/src/services/email.service.ts
@@ -177,6 +177,28 @@ export class EmailService {
 
     await this.sendMail(email, subject, html, simulationLog);
   }
+
+  async sendPasswordResetByAdminEmail(email: string, username: string, tempPass: string) {
+    const subject = 'Contraseña restablecida por Administrador - UT Care';
+    const html = `
+        <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #e0e0e0; border-radius: 8px;">
+          <h2 style="color: #2b6cb0;">Tu contraseña ha sido restablecida</h2>
+          <p>Hola ${username},</p>
+          <p>Un administrador ha restablecido la contraseña de tu cuenta de UT Care.</p>
+          <p>Tus nuevas credenciales de acceso temporal son las siguientes:</p>
+          <div style="background-color: #f7fafc; padding: 15px; border-radius: 5px; border: 1px solid #edf2f7; margin-bottom: 20px;">
+            <p style="margin: 5px 0;"><strong>Usuario:</strong> ${username}</p>
+            <p style="margin: 5px 0;"><strong>Contraseña temporal:</strong> ${tempPass}</p>
+          </div>
+          <p>Por favor, ingresa a la plataforma utilizando estas credenciales. Se te pedirá cambiar esta contraseña temporal inmediatamente en tu primer inicio de sesión.</p>
+          <hr style="border: 0; border-top: 1px solid #e2e8f0; margin: 30px 0;">
+          <p style="color: #a0aec0; font-size: 12px;">Si crees que esto es un error o no estabas enterado de este cambio, por favor contacta con soporte o con el administrador.</p>
+        </div>
+    `;
+    const simulationLog = `[Email simulation] Password reset by Admin email for ${username} (${email}). Temp password: ${tempPass}`;
+
+    await this.sendMail(email, subject, html, simulationLog);
+  }
 }
 
 export default new EmailService();

--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -33,7 +33,7 @@ async function generateUniqueUsername(firstName: string, lastName: string): Prom
 export class UserService {
   async create(data: {
     email: string;
-    password: string;
+    password?: string;
     firstName: string;
     lastName: string;
     dateOfBirth: Date;
@@ -48,7 +48,8 @@ export class UserService {
     }
 
     const username = await generateUniqueUsername(data.firstName, data.lastName);
-    const passwordHash = await hashPassword(data.password);
+    const generatedPassword = data.password || (Math.random().toString(36).substring(2, 12) + 'A1!');
+    const passwordHash = await hashPassword(generatedPassword);
     const confirmationToken = crypto.randomBytes(32).toString('hex');
     const confirmationTokenExpires = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours
 
@@ -80,6 +81,7 @@ export class UserService {
         sex: true,
         role: true,
         isActive: true,
+        isConfirmed: true,
         enrollmentNumber: true,
         createdAt: true,
         updatedAt: true,
@@ -87,7 +89,7 @@ export class UserService {
     });
 
     // Send confirmation email asynchronously without blocking response
-    emailService.sendConfirmationEmail(user.email, user.username, data.password, confirmationToken)
+    emailService.sendConfirmationEmail(user.email, user.username, generatedPassword, confirmationToken)
       .catch((err) => {
         logger.error(`Error sending user confirmation email to ${user.email}:`, err);
       });
@@ -132,6 +134,7 @@ export class UserService {
           sex: true,
           role: true,
           isActive: true,
+          isConfirmed: true,
           enrollmentNumber: true,
           createdAt: true,
           updatedAt: true,
@@ -166,6 +169,7 @@ export class UserService {
         sex: true,
         role: true,
         isActive: true,
+        isConfirmed: true,
         enrollmentNumber: true,
         createdAt: true,
         updatedAt: true,
@@ -215,6 +219,7 @@ export class UserService {
         phone: true,
         role: true,
         isActive: true,
+        isConfirmed: true,
         enrollmentNumber: true,
         updatedAt: true,
       },
@@ -299,6 +304,63 @@ export class UserService {
     });
 
     return { message: 'Contraseña cambiada con éxito.' };
+  }
+
+  async resendConfirmation(id: string) {
+    const user = await prisma.user.findUnique({ where: { id } });
+    if (!user) {
+      throw new AppError('Usuario no encontrado', 404);
+    }
+    if (user.isConfirmed) {
+      throw new AppError('La cuenta ya está confirmada', 400);
+    }
+
+    const generatedPassword = Math.random().toString(36).substring(2, 12) + 'A1!';
+    const passwordHash = await hashPassword(generatedPassword);
+    const confirmationToken = crypto.randomBytes(32).toString('hex');
+    const confirmationTokenExpires = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours
+
+    await prisma.user.update({
+      where: { id },
+      data: {
+        passwordHash,
+        confirmationToken,
+        confirmationTokenExpires,
+        updatedAt: new Date(),
+      },
+    });
+
+    emailService.sendConfirmationEmail(user.email, user.username, generatedPassword, confirmationToken)
+      .catch((err) => {
+        logger.error(`Error sending user confirmation email to ${user.email}:`, err);
+      });
+  }
+
+  async resetPasswordByAdmin(id: string) {
+    const user = await prisma.user.findUnique({ where: { id } });
+    if (!user) {
+      throw new AppError('Usuario no encontrado', 404);
+    }
+    if (user.role === ROLES.ADMIN) {
+      throw new AppError('No se puede restablecer la contraseña del administrador principal', 403);
+    }
+
+    const generatedPassword = Math.random().toString(36).substring(2, 12) + 'A1!';
+    const passwordHash = await hashPassword(generatedPassword);
+
+    await prisma.user.update({
+      where: { id },
+      data: {
+        passwordHash,
+        mustChangePassword: true,
+        updatedAt: new Date(),
+      },
+    });
+
+    emailService.sendPasswordResetByAdminEmail(user.email, user.username, generatedPassword)
+      .catch((err) => {
+        logger.error(`Error sending password reset by admin email to ${user.email}:`, err);
+      });
   }
 }
 

--- a/ut-care/src/components/organisms/DataTable.tsx
+++ b/ut-care/src/components/organisms/DataTable.tsx
@@ -72,6 +72,8 @@ export interface DataTableProps<T> {
   rowVariant?: (row: T) => TableRowVariant
   /** Clase CSS personalizada por fila (ej. bitácora por tipo de acción). */
   rowClassName?: (row: T) => string
+  /** Evento opcional al hacer clic en una fila */
+  onRowClick?: (row: T, event: React.MouseEvent) => void
   /** Formatos de exportación mostrados. */
   exportFormats?: ('pdf' | 'csv' | 'xlsx')[]
   exportFilename?: string
@@ -118,6 +120,7 @@ export function DataTable<T>({
   renderActions,
   rowVariant,
   rowClassName,
+  onRowClick,
   exportFormats = ['pdf', 'csv', 'xlsx'],
   exportFilename = 'datos',
   exportTitle,
@@ -441,7 +444,22 @@ export function DataTable<T>({
                 {data.map((row) => (
                   <tr
                     key={getRowId(row)}
-                    className={rowClassName?.(row) ?? getTableRowClass(rowVariant?.(row) ?? 'default')}
+                    onClick={(e) => {
+                      const target = e.target as HTMLElement
+                      if (
+                        target.closest('button') ||
+                        target.closest('a') ||
+                        target.closest('input') ||
+                        target.closest('select') ||
+                        target.closest('[role="switch"]')
+                      ) {
+                        return
+                      }
+                      onRowClick?.(row, e)
+                    }}
+                    className={`${rowClassName?.(row) ?? getTableRowClass(rowVariant?.(row) ?? 'default')} ${
+                      onRowClick ? 'cursor-pointer hover:bg-black/5 dark:hover:bg-white/5 transition-colors' : ''
+                    }`}
                   >
                     {columns.map((col) => (
                       <td

--- a/ut-care/src/components/organisms/DataTable.tsx
+++ b/ut-care/src/components/organisms/DataTable.tsx
@@ -78,8 +78,8 @@ export interface DataTableProps<T> {
   exportFormats?: ('pdf' | 'csv' | 'xlsx')[]
   exportFilename?: string
   exportTitle?: string
-  /** Claves i18n para la barra de herramientas. */
   i18n?: {
+    actions?: string
     clearFilters?: string
     export?: string
     exportPdf?: string
@@ -437,7 +437,9 @@ export function DataTable<T>({
                       </span>
                     </th>
                   ))}
-                  <th className="w-24 px-4 py-3" />
+                  <th className="w-24 px-4 py-3 font-medium text-[var(--text-primary)]">
+                    {t.actions ?? ''}
+                  </th>
                 </tr>
               </thead>
               <tbody>

--- a/ut-care/src/i18n/locales/en.ts
+++ b/ut-care/src/i18n/locales/en.ts
@@ -1010,6 +1010,7 @@ export const en = {
     required: 'Required',
   },
   table: {
+    actions: 'Actions',
     clearFilters: 'Clear filters',
     rowsPerPage: 'Per page',
     export: 'Export',

--- a/ut-care/src/i18n/locales/es.ts
+++ b/ut-care/src/i18n/locales/es.ts
@@ -1010,6 +1010,7 @@ export const es = {
     required: 'Requerido',
   },
   table: {
+    actions: 'Acciones',
     clearFilters: 'Limpiar filtros',
     rowsPerPage: 'Por página',
     export: 'Exportar',

--- a/ut-care/src/pages/users/UsersPage.tsx
+++ b/ut-care/src/pages/users/UsersPage.tsx
@@ -220,7 +220,8 @@ export function UsersPage() {
             href={`https://wa.me/${cleanNumber}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-[var(--color-primary)] hover:underline flex items-center gap-1"
+            className="hover:underline flex items-center gap-1 font-medium"
+            style={{ color: '#25D366' }}
           >
             {row.phone}
           </a>
@@ -514,38 +515,40 @@ export function UsersPage() {
                   </button>
                 )
               )}
-              {row.role !== 'admin' ? (
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={row.isActive}
-                  title={row.isActive ? 'Desactivar usuario' : 'Activar usuario'}
-                  onClick={() => (row.isActive ? handleDeactivateClick(row) : handleActivateClick(row))}
-                  className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/30 ${
-                    row.isActive ? 'bg-[var(--color-primary)]' : 'bg-[var(--text-muted)]/40'
-                  }`}
-                >
-                  <span
-                    className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition-transform ${
-                      row.isActive ? 'translate-x-5' : 'translate-x-0.5'
+              {row.isConfirmed && (
+                row.role !== 'admin' ? (
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={row.isActive}
+                    title={row.isActive ? 'Desactivar usuario' : 'Activar usuario'}
+                    onClick={() => (row.isActive ? handleDeactivateClick(row) : handleActivateClick(row))}
+                    className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/30 ${
+                      row.isActive ? 'bg-[var(--color-primary)]' : 'bg-[var(--text-muted)]/40'
                     }`}
-                    style={{ marginTop: '2px' }}
-                  />
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={true}
-                  disabled
-                  title="Los administradores no pueden ser desactivados"
-                  className="relative inline-flex h-6 w-11 flex-shrink-0 cursor-not-allowed rounded-full border-2 border-transparent bg-[var(--color-primary)]/50 opacity-60"
-                >
-                  <span
-                    className="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 translate-x-5"
-                    style={{ marginTop: '2px' }}
-                  />
-                </button>
+                  >
+                    <span
+                      className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition-transform ${
+                        row.isActive ? 'translate-x-5' : 'translate-x-0.5'
+                      }`}
+                      style={{ marginTop: '2px' }}
+                    />
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={true}
+                    disabled
+                    title="Los administradores no pueden ser desactivados"
+                    className="relative inline-flex h-6 w-11 flex-shrink-0 cursor-not-allowed rounded-full border-2 border-transparent bg-[var(--color-primary)]/50 opacity-60"
+                  >
+                    <span
+                      className="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 translate-x-5"
+                      style={{ marginTop: '2px' }}
+                    />
+                  </button>
+                )
               )}
             </div>
           )}

--- a/ut-care/src/pages/users/UsersPage.tsx
+++ b/ut-care/src/pages/users/UsersPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Plus, Pencil, Eye } from 'lucide-react'
+import { Plus, Pencil, Eye, Mail, KeyRound } from 'lucide-react'
 import { GlassCard } from '@/components/atoms/GlassCard'
 import { GlassButton } from '@/components/atoms/GlassButton'
 import { LoadingModal } from '@/components/molecules/LoadingModal'
@@ -8,7 +8,7 @@ import { ErrorModal } from '@/components/molecules/ErrorModal'
 import { DataTable } from '@/components/organisms/DataTable'
 import type { DataTableColumn } from '@/components/organisms/DataTable'
 import type { User, CreateUserInput, UpdateUserInput } from '@/types/user'
-import { createUser, deactivateUser, getUsers, updateUser } from '@/services/user.service'
+import { createUser, deactivateUser, getUsers, updateUser, resendConfirmation, resetPasswordByAdmin } from '@/services/user.service'
 import { getDefaultTableLimit } from '@/store/tablePageSize.store'
 import { ROLES, ROLES_VISIBLE_IN_USERS } from '@/constants/roles'
 import { EmailLink } from '@/components/atoms/EmailLink'
@@ -56,15 +56,125 @@ export function UsersPage() {
 
   const [createForm, setCreateForm] = useState<CreateUserInput>({
     email: '',
-    password: '',
     firstName: '',
     lastName: '',
     phone: '',
     role: ROLES.PSICOLOGO,
     enrollmentNumber: '',
   })
-  const [confirmPassword, setConfirmPassword] = useState('')
   const [editForm, setEditForm] = useState<UpdateUserInput>({})
+  const [cooldowns, setCooldowns] = useState<Record<string, number>>({})
+
+  // Initialize cooldowns from sessionStorage on mount
+  useEffect(() => {
+    const activeCooldowns: Record<string, number> = {}
+    const now = Date.now()
+
+    for (let i = 0; i < sessionStorage.length; i++) {
+      const key = sessionStorage.key(i)
+      if (key && (key.startsWith('cooldown_resend_') || key.startsWith('cooldown_reset_'))) {
+        const val = sessionStorage.getItem(key)
+        if (val) {
+          const expiresAt = parseInt(val, 10)
+          const remaining = Math.ceil((expiresAt - now) / 1000)
+          if (remaining > 0) {
+            const shortKey = key.replace('cooldown_', '') // e.g. resend_uuid
+            activeCooldowns[shortKey] = remaining
+          } else {
+            sessionStorage.removeItem(key)
+          }
+        }
+      }
+    }
+    setCooldowns(activeCooldowns)
+  }, [])
+
+  // Timer interval to tick active cooldowns
+  useEffect(() => {
+    const activeKeys = Object.keys(cooldowns)
+    if (activeKeys.length === 0) return
+
+    const interval = setInterval(() => {
+      setCooldowns((prev) => {
+        const next = { ...prev }
+        const now = Date.now()
+        let hasChanges = false
+
+        for (const key of Object.keys(next)) {
+          const storageKey = `cooldown_${key}`
+          const val = sessionStorage.getItem(storageKey)
+          if (val) {
+            const expiresAt = parseInt(val, 10)
+            const remaining = Math.ceil((expiresAt - now) / 1000)
+            if (remaining > 0) {
+              if (next[key] !== remaining) {
+                next[key] = remaining
+                hasChanges = true
+              }
+            } else {
+              delete next[key]
+              sessionStorage.removeItem(storageKey)
+              hasChanges = true
+            }
+          } else {
+            delete next[key]
+            hasChanges = true
+          }
+        }
+
+        return hasChanges ? next : prev
+      })
+    }, 1000)
+
+    return () => clearInterval(interval)
+  }, [cooldowns])
+
+  const startCooldown = (type: 'resend' | 'reset', userId: string) => {
+    const key = `${type}_${userId}`
+    const storageKey = `cooldown_${key}`
+    const durationMs = 30000 // 30 seconds
+    const expiresAt = Date.now() + durationMs
+
+    sessionStorage.setItem(storageKey, String(expiresAt))
+    setCooldowns((prev) => ({
+      ...prev,
+      [key]: 30,
+    }))
+  }
+
+  const handleResendConfirmation = async (user: User) => {
+    setBusy(true)
+    setError(null)
+    try {
+      await resendConfirmation(user.id)
+      startCooldown('resend', user.id)
+    } catch (e: unknown) {
+      const msg =
+        e && typeof e === 'object' && 'response' in e
+          ? (e as { response?: { data?: { message?: string } } }).response?.data?.message
+          : null
+      setError(msg || 'Error al reenviar la confirmación.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleResetPassword = async (user: User) => {
+    setBusy(true)
+    setError(null)
+    try {
+      await resetPasswordByAdmin(user.id)
+      startCooldown('reset', user.id)
+    } catch (e: unknown) {
+      const msg =
+        e && typeof e === 'object' && 'response' in e
+          ? (e as { response?: { data?: { message?: string } } }).response?.data?.message
+          : null
+      setError(msg || 'Error al restablecer la contraseña.')
+    } finally {
+      setBusy(false)
+    }
+  }
 
   const load = () => {
     setLoading(true)
@@ -97,16 +207,43 @@ export function UsersPage() {
       sortable: true,
       render: (row) => (row.email ? <EmailLink email={row.email} /> : '—'),
     },
+    {
+      id: 'phone',
+      label: 'Teléfono',
+      getValue: (row) => row.phone || '—',
+      sortable: true,
+      render: (row) => {
+        if (!row.phone) return '—'
+        const cleanNumber = row.phone.replace(/\D/g, '')
+        return (
+          <a
+            href={`https://wa.me/${cleanNumber}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[var(--color-primary)] hover:underline flex items-center gap-1"
+          >
+            {row.phone}
+          </a>
+        )
+      },
+    },
     { id: 'role', label: t('auditLogs.tableRole'), getValue: (row) => t(`roles.${row.role}`) || row.role, sortable: true },
     {
       id: 'status',
       label: 'Estado',
-      getValue: (row) => (row.isActive ? 'Activo' : 'Inactivo'),
+      getValue: (row) => {
+        if (!row.isConfirmed) return 'No confirmado'
+        return row.isActive ? 'Activo' : 'Desactivado'
+      },
       sortable: true,
       type: 'status',
-      statusMap: { Activo: 'success', Inactivo: 'error' },
+      statusMap: {
+        'No confirmado': 'warning',
+        'Activo': 'success',
+        'Desactivado': 'error',
+      },
     },
-    { id: 'createdAt', label: t('auditLogs.tableDate'), getValue: (row) => row.createdAt ? formatDate(row.createdAt) : '—', sortable: true },
+    { id: 'createdAt', label: 'Fecha de Creación', getValue: (row) => row.createdAt ? formatDate(row.createdAt) : '—', sortable: true },
   ]
 
   const sortedData = useMemo(() => {
@@ -147,10 +284,6 @@ export function UsersPage() {
   }
 
   const submitCreate = async () => {
-    if (createForm.password !== confirmPassword) {
-      setError(t('auth.passwordMismatch'))
-      return
-    }
     setBusy(true)
     setError(null)
     try {
@@ -163,8 +296,7 @@ export function UsersPage() {
         enrollmentNumber: createForm.enrollmentNumber?.trim() || undefined,
       })
       setCreatingOpen(false)
-      setCreateForm({ email: '', password: '', firstName: '', lastName: '', dateOfBirth: '', phone: '', role: ROLES.PSICOLOGO, enrollmentNumber: '' })
-      setConfirmPassword('')
+      setCreateForm({ email: '', firstName: '', lastName: '', phone: '', role: ROLES.PSICOLOGO, enrollmentNumber: '' })
       load()
     } catch (e: unknown) {
       const msg =
@@ -311,6 +443,7 @@ export function UsersPage() {
           getRowId={(row) => row.id}
           loading={loading}
           error={error}
+          onRowClick={(row) => setViewingUser(row)}
           emptyMessage="No hay usuarios."
           pagination={pagination}
           onPageChange={setPage}
@@ -356,6 +489,31 @@ export function UsersPage() {
                 <Pencil size={16} />
                 {t('common.edit')}
               </button>
+              {!row.isConfirmed ? (
+                <button
+                  type="button"
+                  disabled={cooldowns[`resend_${row.id}`] !== undefined}
+                  onClick={() => handleResendConfirmation(row)}
+                  className="inline-flex items-center gap-1 text-[var(--color-primary)] hover:underline disabled:opacity-50 disabled:no-underline"
+                  title="Reenviar correo de confirmación"
+                >
+                  <Mail size={16} />
+                  {cooldowns[`resend_${row.id}`] !== undefined ? `${cooldowns[`resend_${row.id}`]}s` : 'Reenviar'}
+                </button>
+              ) : (
+                row.role !== 'admin' && (
+                  <button
+                    type="button"
+                    disabled={cooldowns[`reset_${row.id}`] !== undefined}
+                    onClick={() => handleResetPassword(row)}
+                    className="inline-flex items-center gap-1 text-[var(--color-primary)] hover:underline disabled:opacity-50 disabled:no-underline"
+                    title="Restablecer contraseña"
+                  >
+                    <KeyRound size={16} />
+                    {cooldowns[`reset_${row.id}`] !== undefined ? `${cooldowns[`reset_${row.id}`]}s` : 'Restablecer'}
+                  </button>
+                )
+              )}
               {row.role !== 'admin' ? (
                 <button
                   type="button"
@@ -428,30 +586,10 @@ export function UsersPage() {
 
             <div className="grid gap-4 sm:grid-cols-2">
               {creatingOpen && (
-                <>
-                  <div className="sm:col-span-2">
-                    <label className="block text-sm font-medium text-[var(--text-primary)] mb-1">{t('auth.email')}</label>
-                    <input className="glass-input w-full px-4 py-2.5" value={createForm.email} onChange={(e) => setCreateForm((p) => ({ ...p, email: e.target.value }))} />
-                  </div>
-                  <div className="sm:col-span-2">
-                    <label className="block text-sm font-medium text-[var(--text-primary)] mb-1">{t('auth.password')}</label>
-                    <PasswordInput
-                      className=""
-                      value={createForm.password}
-                      onChange={(e) => setCreateForm((p) => ({ ...p, password: e.target.value }))}
-                      placeholder="••••••••"
-                      showStrength
-                    />
-                  </div>
-                  <div className="sm:col-span-2">
-                    <label className="block text-sm font-medium text-[var(--text-primary)] mb-1">{t('auth.confirmPassword')}</label>
-                    <PasswordInput
-                      value={confirmPassword}
-                      onChange={(e) => setConfirmPassword(e.target.value)}
-                      placeholder="••••••••"
-                    />
-                  </div>
-                </>
+                <div className="sm:col-span-2">
+                  <label className="block text-sm font-medium text-[var(--text-primary)] mb-1">{t('auth.email')}</label>
+                  <input className="glass-input w-full px-4 py-2.5" value={createForm.email} onChange={(e) => setCreateForm((p) => ({ ...p, email: e.target.value }))} />
+                </div>
               )}
 
               <div>
@@ -509,7 +647,7 @@ export function UsersPage() {
             </div>
 
             <div className="mt-6 flex justify-end gap-2">
-              <GlassButton type="button" onClick={() => { setCreatingOpen(false); setEditing(null); setConfirmPassword(''); }}>
+              <GlassButton type="button" onClick={() => { setCreatingOpen(false); setEditing(null); }}>
                 {t('common.cancel')}
               </GlassButton>
               <GlassButton type="button" variant="primary" onClick={creatingOpen ? submitCreate : handleSaveEditClick} disabled={busy}>
@@ -561,12 +699,20 @@ export function UsersPage() {
               <div>
                 <span className="text-xs font-semibold text-[var(--text-secondary)] block uppercase tracking-wider">Estado de Cuenta</span>
                 <span className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium mt-1 ${
-                  viewingUser.isActive 
-                    ? 'bg-emerald-500/10 text-emerald-500 border border-emerald-500/20' 
+                  !viewingUser.isConfirmed
+                    ? 'bg-amber-500/10 text-amber-500 border border-amber-500/20'
+                    : viewingUser.isActive
+                    ? 'bg-emerald-500/10 text-emerald-500 border border-emerald-500/20'
                     : 'bg-rose-500/10 text-rose-500 border border-rose-500/20'
                 }`}>
-                  <span className={`h-1.5 w-1.5 rounded-full ${viewingUser.isActive ? 'bg-emerald-500' : 'bg-rose-500'}`} />
-                  {viewingUser.isActive ? 'Activo' : 'Inactivo'}
+                  <span className={`h-1.5 w-1.5 rounded-full ${
+                    !viewingUser.isConfirmed
+                      ? 'bg-amber-500'
+                      : viewingUser.isActive
+                      ? 'bg-emerald-500'
+                      : 'bg-rose-500'
+                  }`} />
+                  {!viewingUser.isConfirmed ? 'No confirmado' : viewingUser.isActive ? 'Activo' : 'Desactivado'}
                 </span>
               </div>
               <div>

--- a/ut-care/src/pages/users/UsersPage.tsx
+++ b/ut-care/src/pages/users/UsersPage.tsx
@@ -15,7 +15,7 @@ import { EmailLink } from '@/components/atoms/EmailLink'
 import { PasswordInput } from '@/components/atoms/PasswordInput'
 
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, { dateStyle: 'short' })
+  return new Date(iso).toLocaleDateString(undefined, { day: 'numeric', month: 'long', year: 'numeric' })
 }
 
 function fullName(u: User): string {

--- a/ut-care/src/pages/users/UsersPage.tsx
+++ b/ut-care/src/pages/users/UsersPage.tsx
@@ -557,6 +557,7 @@ export function UsersPage() {
           exportFilename="usuarios"
           exportTitle={t('nav.users')}
           i18n={{
+            actions: t('table.actions'),
             clearFilters: t('table.clearFilters'),
             export: t('table.export'),
             exportPdf: t('table.exportPdf'),

--- a/ut-care/src/pages/users/UsersPage.tsx
+++ b/ut-care/src/pages/users/UsersPage.tsx
@@ -583,7 +583,7 @@ export function UsersPage() {
               <button
                 type="button"
                 className="text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-                onClick={() => { setCreatingOpen(false); setEditing(null); setConfirmPassword(''); }}
+                onClick={() => { setCreatingOpen(false); setEditing(null); }}
               >
                 ✕
               </button>

--- a/ut-care/src/pages/users/UsersPage.tsx
+++ b/ut-care/src/pages/users/UsersPage.tsx
@@ -14,16 +14,17 @@ import { ROLES, ROLES_VISIBLE_IN_USERS } from '@/constants/roles'
 import { EmailLink } from '@/components/atoms/EmailLink'
 import { PasswordInput } from '@/components/atoms/PasswordInput'
 
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, { day: 'numeric', month: 'long', year: 'numeric' })
-}
+
 
 function fullName(u: User): string {
   return `${u.firstName} ${u.lastName}`.trim()
 }
 
 export function UsersPage() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
+  const formatDate = (iso: string): string => {
+    return new Date(iso).toLocaleDateString(i18n.language, { day: 'numeric', month: 'long', year: 'numeric' })
+  }
   const [users, setUsers] = useState<User[]>([])
   const [loading, setLoading] = useState(true)
   const [busy, setBusy] = useState(false)

--- a/ut-care/src/services/user.service.ts
+++ b/ut-care/src/services/user.service.ts
@@ -47,3 +47,11 @@ export async function deactivateUser(id: string, adminPassword?: string): Promis
   await api.delete(`/users/${id}`, config)
 }
 
+export async function resendConfirmation(id: string): Promise<void> {
+  await api.post(`/users/${id}/resend-confirmation`)
+}
+
+export async function resetPasswordByAdmin(id: string): Promise<void> {
+  await api.post(`/users/${id}/reset-password-admin`)
+}
+

--- a/ut-care/src/types/user.ts
+++ b/ut-care/src/types/user.ts
@@ -8,6 +8,7 @@ export interface User {
   phone: string | null
   role: string
   isActive: boolean
+  isConfirmed: boolean
   enrollmentNumber: string | null
   createdAt?: string
   updatedAt?: string
@@ -20,7 +21,6 @@ export interface UsersResponse {
 
 export interface CreateUserInput {
   email: string
-  password: string
   firstName: string
   lastName: string
   dateOfBirth?: string


### PR DESCRIPTION
Este Pull Request incorpora los siguientes cambios solicitados al módulo de usuarios:

- **Creación de usuarios sin contraseña:** Se eliminó el campo de contraseña del formulario en el cliente. El backend ahora genera automáticamente una contraseña temporal segura y la envía por correo en el mensaje de bienvenida.
- **Tres estados de cuenta:** Visualización del estado mediante badges en la tabla ("No confirmado", "Activo", "Desactivado"). El switch de activar/desactivar solo está visible para cuentas confirmadas.
- **Columna de teléfono a WhatsApp:** Nueva columna con el número del usuario enlazado directamente a su chat de WhatsApp, con el color verde oficial de la marca (`#25D366`).
- **Fecha de creación:** Renombrado de la cabecera de la columna "Fecha" a "Fecha de Creación".
- **Modal de detalles al hacer clic en la fila:** Implementado el evento de clic en la fila de la tabla para abrir el modal de detalles (con descarte automático de los elementos interactivos).
- **Reenvío y Restablecimiento con Cooldown:** Implementación de acciones con un temporizador de enfriamiento de 30 segundos persistido en `sessionStorage` que resiste recargas de la página.