### PR TITLE
fix: Corregir detección de sesión expirada al fallar la verficación de token

### DIFF
--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -30,7 +30,7 @@ export const authenticateToken = (
     next();
   } catch (error) {
     logger.error('Authentication error:', error);
-    res.status(403).json({
+    res.status(401).json({
       success: false,
       message: 'Invalid or expired token',
     });

--- a/ut-care/src/lib/api.ts
+++ b/ut-care/src/lib/api.ts
@@ -24,8 +24,13 @@ api.interceptors.response.use(
   (err) => {
     const status = err.response?.status
     const url = err.config?.url || ''
-    // Solo cerrar sesión en 401 cuando no sea un intento explícito de login
-    if (status === 401 && !url.includes('/auth/login')) {
+    const message = err.response?.data?.message || ''
+
+    // Cerrar sesión si el token es inválido o expiró (401 o 403 con mensaje específico de token)
+    const isUnauthorized = status === 401 && !url.includes('/auth/login')
+    const isTokenExpiredForbidden = status === 403 && message === 'Invalid or expired token'
+
+    if (isUnauthorized || isTokenExpiredForbidden) {
       useAuthStore.getState().setSessionExpired(true)
     }
     return Promise.reject(err)


### PR DESCRIPTION
### Descripción
Este PR corrige el comportamiento del sistema cuando el token JWT del usuario expira. Asegura que el frontend detecte correctamente la caducidad del token y muestre la modal de sesión expirada en lugar de fallar silenciosamente en el fondo.

### Cambios principales:
 - **Backend API:**
    - Modificado el middleware de autenticación (´api/src/middleware/auth.ts´) para retornar un código de estado ´401 Unauthorized´ (en lugar de ´403 Forbidden´) cuando la verificación del token falla debido a que el token no es válido o ha expirado.

- **Frontend Web:**
  - Actualizado el interceptor global Axios (´ut-care/src/lib/api.ts´) para detectar las respuestas ´401´ o que las respuestas ´403´ que contengan el mensaje específico de ´'Invalid or expired token'´. Al capturarlo, se activa el estado de sesión expirada, mostrando la modal y redirigiendo al login.