### PR TITLE
feat (AppEHR): Actualizar Inicio de sesión, recuperar contraseña y conexion a Render.

### DIFF
--- a/AppEHR.Tests/ViewModelTests.cs
+++ b/AppEHR.Tests/ViewModelTests.cs
@@ -69,7 +69,7 @@ namespace AppEHR.Tests
             }";
 
 
-            viewModel.Email = "admin@test.com";
+            viewModel.Username = "admin_user";
             viewModel.Password = "password";
 
             // Act

--- a/AppEHR/Services/ApiService.cs
+++ b/AppEHR/Services/ApiService.cs
@@ -18,25 +18,7 @@ namespace AppEHR.Services
         public ApiService()
         {
             _client = new HttpClient();
-            // Adaptar la dirección local según el dispositivo y entorno
-            try
-            {
-                if (DeviceInfo.Platform == DevicePlatform.Android)
-                {
-                    // Si es un emulador usa 10.0.2.2. Si es un dispositivo físico usa localhost (requiere adb reverse)
-                    _baseUrl = DeviceInfo.DeviceType == DeviceType.Virtual
-                        ? "http://10.0.2.2:5000/api"
-                        : "http://localhost:5000/api";
-                }
-                else
-                {
-                    _baseUrl = "http://localhost:5000/api";
-                }
-            }
-            catch
-            {
-                _baseUrl = "http://localhost:5000/api";
-            }
+            _baseUrl = "https://ehr-api-prod.onrender.com/api";
         }
 
         private async Task ApplyAuthHeaderAsync()

--- a/AppEHR/Services/AuthService.cs
+++ b/AppEHR/Services/AuthService.cs
@@ -113,6 +113,26 @@ namespace AppEHR.Services
             }
         }
 
+        public async Task<(bool Success, string Message)> ForgotPasswordAsync(string email)
+        {
+            try
+            {
+                var payload = new { email };
+                var response = await _apiService.PostAsync("auth/forgot-password", payload);
+                var content = await response.Content.ReadAsStringAsync();
+
+                using var doc = JsonDocument.Parse(content);
+                var success = doc.RootElement.GetProperty("success").GetBoolean();
+                var message = doc.RootElement.GetProperty("message").GetString() ?? string.Empty;
+
+                return (success, message);
+            }
+            catch (Exception ex)
+            {
+                return (false, $"Error de conexión: {ex.Message}");
+            }
+        }
+
         public async Task LogoutAsync()
         {
             try

--- a/AppEHR/Services/AuthService.cs
+++ b/AppEHR/Services/AuthService.cs
@@ -57,11 +57,11 @@ namespace AppEHR.Services
             }
         }
 
-        public async Task<(bool Success, string Message)> LoginAsync(string email, string password)
+        public async Task<(bool Success, string Message)> LoginAsync(string username, string password)
         {
             try
             {
-                var credentials = new { email, password };
+                var credentials = new { username, password };
                 var response = await _apiService.PostAsync("auth/login", credentials);
                 var content = await response.Content.ReadAsStringAsync();
 

--- a/AppEHR/ViewModels/LoginViewModel.cs
+++ b/AppEHR/ViewModels/LoginViewModel.cs
@@ -9,7 +9,7 @@ namespace AppEHR.ViewModels
     public class LoginViewModel : BaseViewModel
     {
         private readonly AuthService _authService;
-        private string _email = string.Empty;
+        private string _username = string.Empty;
         private string _password = string.Empty;
         private string _errorMessage = string.Empty;
         private bool _rememberMe;
@@ -21,10 +21,10 @@ namespace AppEHR.ViewModels
             LoginCommand = new Command(async () => await ExecuteLoginCommandAsync(), () => !IsBusy);
         }
 
-        public string Email
+        public string Username
         {
-            get => _email;
-            set => SetProperty(ref _email, value);
+            get => _username;
+            set => SetProperty(ref _username, value);
         }
 
         public string Password
@@ -51,9 +51,9 @@ namespace AppEHR.ViewModels
         {
             if (IsBusy) return;
 
-            if (string.IsNullOrWhiteSpace(Email) || string.IsNullOrWhiteSpace(Password))
+            if (string.IsNullOrWhiteSpace(Username) || string.IsNullOrWhiteSpace(Password))
             {
-                ErrorMessage = "Ingresa correo y contraseña";
+                ErrorMessage = "Ingresa usuario y contraseña";
                 return;
             }
 
@@ -62,7 +62,7 @@ namespace AppEHR.ViewModels
 
             try
             {
-                var result = await _authService.LoginAsync(Email.Trim(), Password);
+                var result = await _authService.LoginAsync(Username.Trim(), Password);
                 if (result.Success)
                 {
                     try

--- a/AppEHR/ViewModels/LoginViewModel.cs
+++ b/AppEHR/ViewModels/LoginViewModel.cs
@@ -46,6 +46,19 @@ namespace AppEHR.ViewModels
             set => SetProperty(ref _rememberMe, value);
         }
 
+        public new bool IsBusy
+        {
+            get => base.IsBusy;
+            set
+            {
+                if (base.IsBusy != value)
+                {
+                    base.IsBusy = value;
+                    ((Command)LoginCommand).ChangeCanExecute();
+                }
+            }
+        }
+
         public ICommand LoginCommand { get; }
         public ICommand ForgotPasswordCommand { get; }
 

--- a/AppEHR/ViewModels/LoginViewModel.cs
+++ b/AppEHR/ViewModels/LoginViewModel.cs
@@ -19,6 +19,7 @@ namespace AppEHR.ViewModels
             _authService = authService;
             Title = "Iniciar Sesión";
             LoginCommand = new Command(async () => await ExecuteLoginCommandAsync(), () => !IsBusy);
+            ForgotPasswordCommand = new Command(async () => await ExecuteForgotPasswordCommandAsync());
         }
 
         public string Username
@@ -46,6 +47,7 @@ namespace AppEHR.ViewModels
         }
 
         public ICommand LoginCommand { get; }
+        public ICommand ForgotPasswordCommand { get; }
 
         private async Task ExecuteLoginCommandAsync()
         {
@@ -84,7 +86,56 @@ namespace AppEHR.ViewModels
             }
             catch (System.Exception ex)
             {
-                ErrorMessage = $"Error: {ex.Message}";
+                ErrorMessage = $"Error de conexión: {ex.Message}";
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        private async Task ExecuteForgotPasswordCommandAsync()
+        {
+            if (IsBusy) return;
+
+            string email = await Shell.Current.DisplayPromptAsync(
+                "Restablecer Contraseña",
+                "Ingresa tu correo electrónico registrado:",
+                "Enviar",
+                "Cancelar",
+                "correo@ejemplo.com",
+                -1,
+                Keyboard.Email
+            );
+
+            if (string.IsNullOrWhiteSpace(email)) return;
+
+            IsBusy = true;
+            ErrorMessage = string.Empty;
+
+            try
+            {
+                var result = await _authService.ForgotPasswordAsync(email.Trim());
+                if (result.Success)
+                {
+                    await Shell.Current.DisplayAlert(
+                        "Correo Enviado",
+                        result.Message ?? "Se ha enviado un enlace para restablecer tu contraseña. Revisa tu bandeja de entrada.",
+                        "Aceptar"
+                    );
+                }
+                else
+                {
+                    await Shell.Current.DisplayAlert(
+                        "Error",
+                        result.Message ?? "No se pudo enviar el correo de restablecimiento.",
+                        "Aceptar"
+                    );
+                }
+            }
+            catch (System.Exception ex)
+            {
+                await Shell.Current.DisplayAlert("Error", $"Error de conexión: {ex.Message}", "Aceptar");
             }
             finally
             {

--- a/AppEHR/ViewModels/QuickAppointmentViewModel.cs
+++ b/AppEHR/ViewModels/QuickAppointmentViewModel.cs
@@ -224,6 +224,21 @@ namespace AppEHR.ViewModels
         }
         #endregion
 
+        public new bool IsBusy
+        {
+            get => base.IsBusy;
+            set
+            {
+                if (base.IsBusy != value)
+                {
+                    base.IsBusy = value;
+                    ((Command)SearchPatientCommand).ChangeCanExecute();
+                    ((Command)BookAppointmentCommand).ChangeCanExecute();
+                    ((Command)RegisterPatientCommand).ChangeCanExecute();
+                }
+            }
+        }
+
         public ICommand SearchPatientCommand { get; }
         public ICommand BookAppointmentCommand { get; }
         public ICommand RegisterPatientCommand { get; }

--- a/AppEHR/Views/LoginPage.xaml
+++ b/AppEHR/Views/LoginPage.xaml
@@ -55,9 +55,9 @@
 
                     <VerticalStackLayout Spacing="16">
                         
-                        <!-- Email Input -->
+                        <!-- Username Input -->
                         <VerticalStackLayout Spacing="6">
-                            <Label Text="Correo Institucional" 
+                            <Label Text="Nombre de Usuario" 
                                    FontSize="12" 
                                    FontAttributes="Bold" 
                                    TextColor="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
@@ -67,9 +67,9 @@
                                 <Border.StrokeShape>
                                     <RoundRectangle CornerRadius="8" />
                                 </Border.StrokeShape>
-                                <Entry Text="{Binding Email}" 
-                                       Placeholder="nombre@institucion.edu.mx" 
-                                       Keyboard="Email" 
+                                <Entry Text="{Binding Username}" 
+                                       Placeholder="Introduce tu usuario" 
+                                       Keyboard="Default" 
                                        TextColor="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
                                        PlaceholderColor="Gray"
                                        Margin="6,0"

--- a/AppEHR/Views/LoginPage.xaml
+++ b/AppEHR/Views/LoginPage.xaml
@@ -126,6 +126,18 @@
                                 HeightRequest="48"
                                 Margin="0,8,0,0"/>
 
+                        <!-- Forgot Password Link -->
+                        <Button Text="¿Olvidaste tu contraseña?"
+                                Command="{Binding ForgotPasswordCommand}"
+                                BackgroundColor="Transparent"
+                                TextColor="{StaticResource BrandPrimary}"
+                                FontSize="13"
+                                FontAttributes="Bold"
+                                HorizontalOptions="Center"
+                                HeightRequest="38"
+                                Padding="0"
+                                Margin="0,4,0,0"/>
+
                         <!-- Loading Indicator -->
                         <ActivityIndicator IsRunning="{Binding IsBusy}" 
                                            IsVisible="{Binding IsBusy}" 


### PR DESCRIPTION
Este Pull Request agrupa las actualizaciones de autenticación y conectividad para la aplicación móvil **AppEHR**, permitiendo su correcto funcionamiento contra el servidor del backend desplegado en producción.

### 🚀 Cambios Principales

1. **Inicio de sesión con Nombre de Usuario:**
   - Se modificó el formulario de inicio de sesión en `LoginPage.xaml` para requerir el **Nombre de Usuario** en lugar del correo electrónico.
   - Se actualizaron los bindings del `LoginViewModel` y las pruebas unitarias correspondientes en `AppEHR.Tests`.

2. **Opción "¿Olvidaste tu contraseña?":**
   - **Interfaz (XAML):** Se añadió el enlace visual "¿Olvidaste tu contraseña?" debajo del botón de iniciar sesión.
   - **ViewModel y Servicio:** Se creó el flujo que solicita el correo electrónico del usuario mediante un prompt nativo (`DisplayPromptAsync`) y consume el endpoint `POST /auth/forgot-password` a través del `AuthService`.

3. **Conexión Directa al Backend en la Nube (Render):**
   - Se actualizó la URL base en `ApiService.cs` para apuntar a `https://ehr-api-prod.onrender.com/api`. Al utilizar `HTTPS`, la aplicación puede conectarse en cualquier plataforma (Windows, emuladores y dispositivos Android físicos) sin requerir reenvío de puertos (`adb reverse`).

4. **Corrección del bloqueo de botones (Bug de IsBusy):**
   - Se solucionó un bug crítico donde los botones (como el de "Agendar Cita Rápida") se quedaban congelados (deshabilitados) después de completar una llamada asíncrona. Se implementó sombreado de la propiedad `IsBusy` en los ViewModels para forzar la re-evaluación del estado de los comandos (`ChangeCanExecute`).

### 🧪 Verificación Realizada

- **Pruebas Unitarias:** Ejecución exitosa de la suite de pruebas unitarias con `dotnet test` (3/3 pruebas superadas).
- **Compilación:** Verificación de compilación exitosa del cliente para Android y Windows.
- **Conectividad:** Pruebas de consulta de endpoints HTTPS del backend en Render finalizadas correctamente.